### PR TITLE
add phantomjs in docker

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,7 @@
 FROM ruby:2.6.5
-RUN apt-get update -qq && apt-get install -y build-essential libpq-dev nodejs
+RUN apt-get update -qq && apt-get install -y build-essential libpq-dev nodejs npm
+RUN npm -g install yarn
+RUN yarn global add phantomjs-prebuilt
 RUN mkdir /myapp
 WORKDIR /myapp
 ADD Gemfile /myapp/Gemfile

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -7,3 +7,5 @@ services:
       - .:/myapp
     ports:
       - "3000:3000"
+    environment:
+      OPENSSL_CONF: /etc/ssl/


### PR DESCRIPTION
There is a problem with the Ubuntu package version of phantomjs, which causes capybara errors.
The version of npm that can be installed with the ubuntu package gives an error when installing phantomjs.
So, install yarn using npm, and install phantomjs using yarn.

see: Medium/phantomjs#707